### PR TITLE
Ajout de la propriété altDeploymentRepository

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -29,6 +29,10 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: >
+           mvn deploy
+           -DaltDeploymentRepository=$MAVEN_REPO_INFOS
+           -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        MAVEN_REPO_INFOS: github::default::https://maven.pkg.github.com/FredericLanic/ladybug


### PR DESCRIPTION
Pour passer les infos sur le serveur Maven de Github (qui fonctionne comme un _Nexus_)

## Dépot de l'artifact

 Voir la [doc de github](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) pour le dépot d'artifact Maven sur _Guthub Package_

### Utilisation de la propriété `altDeploymentRepository`

Ici, on ne passe pas par le `pom.xml` pour injecter les infos, mais directement dans la commande via la propriété `altDeploymentRepository`.

Voir <http://code418.com/maven-github-repository-instructions/> pour le format de cette propriété.

````
-DaltDeploymentRepository=id::layout::url
````

#### Id du serveur et settings.xml

L'id `github` que j'ai utilisé ici est défini dans le `settings.xml` injecté par `uses: actions/setup-java@v2`.

Ce fichier contient un bloc `<servers>` comme ceci : 

````xml
<server>
      <id>github</id>
      <username>${env.GITHUB_ACTOR}</username>
      <password>${env.GITHUB_TOKEN}</password>
</server>
````

Voir la doc ici : <https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven>


### Plusieurs lignes avec la syntaxe YAML chevron `>`

Enfin la syntaxe avec chevron permet, dans un fichier YAML, d'écrire une chaine mono-ligne sur plusieurs lignes.

Voir l'exemple ci-dessous : 

```yaml
steps:
    - name: Yolo
      run: >
              echo "une commande
              écrite sur plusieurs lignes dans le YAML
              mais parsée en une seule ligne...."
````

### Utilisation d'une variable d'environnement

Pour améliorer la lisibilité du jab, j'ai déclaré une variable `MAVEN_REPO_INFOS` dans la section `env`.

Je peux ensuite l'utiliser dans ma commande, avec la syntaxe `$MAVEN_REPO_INFOS`.