### PR TITLE
Retrait du maven-shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,35 +108,9 @@
                         <version>${spring-loaded.version}</version>
                     </dependency>
                 </dependencies>
-            </plugin>			           
+            </plugin>
 
-        	<plugin>
-	            <groupId>org.apache.maven.plugins</groupId>
-	            <artifactId>maven-shade-plugin</artifactId>
-	            <executions>
-	                <execution>
-	                    <phase>package</phase>
-	                    <goals>
-	                        <goal>shade</goal>
-	                    </goals>
-	                </execution>
-	            </executions>
-	            <configuration>
-	                <shadedArtifactAttached>true</shadedArtifactAttached>
-	                <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-	                <filters>
-	                    <filter>
-	                        <artifact>*:*</artifact>
-	                        <excludes>
-	                            <exclude>META-INF/*.SF</exclude>
-	                            <exclude>META-INF/*.DSA</exclude>
-	                            <exclude>META-INF/*.RSA</exclude>
-	                        </excludes>
-	                    </filter>
-	                </filters>
-	            </configuration>
-	        </plugin> 
-               
+
         	<!-- voir https://spring.io/blog/2020/03/11/spring-tips-java-14-or-can-your-java-do-this -->
 			
         </plugins>


### PR DESCRIPTION
Salut Fred !

Suite aux cafés d'hier :  le `maven-shade-plugin` est inutile ici car en doublon avec le `spring-boot-maven-plugin`

Le seul `spring-boot-maven-plugin`, déjà présent dans ton `pom.xml`, est suffisant pour créer un fatjar exécutable.

C'est le sens du `spring-boot-maven-plugin:1.2.7.RELEASE:repackage (default)` à la fin des logs du `mvn package`  
Voir <https://docs.spring.io/spring-boot/docs/1.4.1.RELEASE/maven-plugin/repackage-mojo.html>

```
[INFO] --- maven-jar-plugin:2.5:jar (default-jar) @ ladybug ---
[INFO] Building jar: C:\Users\jetevenard\Desktop\UPDEV\ladybug\target\ladybug-0.3.1.jar
[INFO]
[INFO] --- spring-boot-maven-plugin:1.2.7.RELEASE:repackage (default) @ ladybug ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.779 s
[INFO] Finished at: 2022-03-03T16:18:51+01:00
[INFO] ------------------------------------------------------------------------
```

Il suffit donc de lancer `java -jar target/ladybug-x.x.x.jar` après un `mvn clean package` et voilà