### PR TITLE
Issue #11 : Platform independant

### DIFF
--- a/src/main/java/com/kycox/game/controller/XboxOneController.java
+++ b/src/main/java/com/kycox/game/controller/XboxOneController.java
@@ -8,13 +8,17 @@ import com.kycox.game.controller.xboxone.XBoxOneControllerManager;
 import com.kycox.game.controller.xboxone.XboxRequest;
 import com.kycox.game.message.GameMessages;
 import com.kycox.game.message.GameMessaging;
+import com.kycox.game.os.WindowsHost;
 import com.kycox.game.properties.GameProperties;
+
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 import java.util.Observable;
 import java.util.Observer;
 
 @Component
+@Conditional(WindowsHost.class)
 public class XboxOneController extends XBoxOneControllerManager implements Observer {
 
 	private final GameMessaging gameMessaging;

--- a/src/main/java/com/kycox/game/controller/xboxone/XBoxOneControllerManager.java
+++ b/src/main/java/com/kycox/game/controller/xboxone/XBoxOneControllerManager.java
@@ -1,12 +1,16 @@
 package com.kycox.game.controller.xboxone;
 
+import com.kycox.game.os.WindowsHost;
 import com.studiohartman.jamepad.ControllerManager;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
+
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 
 @Component
+@Conditional(WindowsHost.class)
 public class XBoxOneControllerManager {
 
 	@Getter

--- a/src/main/java/com/kycox/game/controller/xboxone/XboxRequest.java
+++ b/src/main/java/com/kycox/game/controller/xboxone/XboxRequest.java
@@ -1,13 +1,16 @@
 package com.kycox.game.controller.xboxone;
 
 import com.kycox.game.constant.XboxOneConstants;
+import com.kycox.game.os.WindowsHost;
 import com.studiohartman.jamepad.ControllerState;
 import lombok.Getter;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
+@Conditional(WindowsHost.class)
 @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class XboxRequest {
 	@Getter

--- a/src/main/java/com/kycox/game/engine/Engine.java
+++ b/src/main/java/com/kycox/game/engine/Engine.java
@@ -23,6 +23,8 @@ import com.kycox.game.view.CentralView;
 import com.kycox.game.view.down.PageEndView;
 import com.kycox.game.view.left.PageLeftView;
 import jakarta.annotation.PostConstruct;
+
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,7 +36,7 @@ public class Engine {
 	private final PageLeftView pageLeftView;
 	private final XboxOneController xboxOneController;
 
-	public Engine(GameModel gameModel, GameSounds gameSounds, CentralView centralView, PageEndView pageEndView, PageLeftView pageLeftView, XboxOneController xboxOneController) {
+	public Engine(GameModel gameModel, GameSounds gameSounds, CentralView centralView, PageEndView pageEndView, PageLeftView pageLeftView, @Nullable XboxOneController xboxOneController) {
 		this.gameModel = gameModel;
 		this.gameSounds = gameSounds;
 		this.centralView = centralView;
@@ -53,7 +55,7 @@ public class Engine {
 		gameModel.addObserver(gameSounds);
 		gameModel.addObserver(pageEndView);
 		gameModel.addObserver(pageLeftView);
-		gameModel.addObserver(xboxOneController);
+		if(xboxOneController != null) gameModel.addObserver(xboxOneController);
 		// on récupère la longueur du son de la mort de ladybug et on l'affecte
 		gameModel.getLadybugDying().setMillisecondLenght(gameSounds.getMillisecondLadybugDeath());
 		gameModel.setBeginningMilliseconds(gameSounds.getMillisecondsBeginning());

--- a/src/main/java/com/kycox/game/os/WindowsHost.java
+++ b/src/main/java/com/kycox/game/os/WindowsHost.java
@@ -1,0 +1,19 @@
+package com.kycox.game.os;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition Spring pour vérifier si le Système hôte est Windows (Librairies XBox)
+ */
+public class WindowsHost implements Condition {
+
+	private static final String WINDOWS = "Windows";
+	private static final String OS_NAME_PROP = "os.name";
+
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		return System.getProperty(OS_NAME_PROP).startsWith(WINDOWS);
+	}
+}


### PR DESCRIPTION
Implémentation d'une `Condition` Spring pour tester si l'OS hôte est Windows  
Plus d'info : https://www.baeldung.com/spring-conditional-annotations

Les  Bean qui concernent la XBox ne seront instanciés que sur Windows.  
(Puisqu'ils font - indirectement - appel à du code natif Windows)

Ajout d'une @Nullable dans le constructeur de Engine, et d'un check si != null pour l'ajouter aux Observers machin turc.

En principe, plus besoin alors d'une "version mac" sur une autre branche !